### PR TITLE
Run `hasOwnProperty` on object

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function get (obj, path) {
   var keys = path.split('.');
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
-    if (!obj || !hasOwnProperty.call(obj, key)) {
+    if (!obj || !obj.hasOwnProperty(key)) {
       obj = undefined;
       break;
     }
@@ -22,7 +22,7 @@ function set (obj, path, value) {
   var keys = path.split('.');
   for (var i = 0; i < keys.length - 1; i++) {
     var key = keys[i];
-    if (deep.p && !hasOwnProperty.call(obj, key)) obj[key] = {};
+    if (deep.p && !obj.hasOwnProperty(key)) obj[key] = {};
     obj = obj[key];
   }
   obj[keys[i]] = value;


### PR DESCRIPTION
If run on global object, it will throw error in older browsers like IE8.
