### PR TITLE
Fix `hasOwnProperty` check in IE<9

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var hasOwnProp = Object.prototype.hasOwnProperty;
+
 module.exports = deep;
 
 function deep (obj, path, value) {
@@ -9,7 +11,7 @@ function get (obj, path) {
   var keys = path.split('.');
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
-    if (!obj || !hasOwnProperty.call(obj, key)) {
+    if (!obj || !hasOwnProp.call(obj, key)) {
       obj = undefined;
       break;
     }
@@ -22,7 +24,7 @@ function set (obj, path, value) {
   var keys = path.split('.');
   for (var i = 0; i < keys.length - 1; i++) {
     var key = keys[i];
-    if (deep.p && !hasOwnProperty.call(obj, key)) obj[key] = {};
+    if (deep.p && !hasOwnProp.call(obj, key)) obj[key] = {};
     obj = obj[key];
   }
   obj[keys[i]] = value;


### PR DESCRIPTION
I already opened one PR for this, but closed it due to my mistake. It turns out it was IE error and this PR should fix it. Error is explained in this [StackOverflow post](http://stackoverflow.com/a/1186510/178058).

Hope you will merge this PR!