### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,10 @@ var hasOwnProp = Object.prototype.hasOwnProperty;
 
 module.exports = deep;
 
+function isSafeKey (key) {
+  return key !== '__proto__' && key !== 'prototype' && key !== 'constructor';
+}
+
 function deep (obj, path, value) {
   if (arguments.length === 3) return set.apply(null, arguments);
   return get.apply(null, arguments);
@@ -11,7 +15,7 @@ function get (obj, path) {
   var keys = Array.isArray(path) ? path : path.split('.');
   for (var i = 0; i < keys.length; i++) {
     var key = keys[i];
-    if (!obj || !hasOwnProp.call(obj, key)) {
+    if (!obj || !hasOwnProp.call(obj, key) || !isSafeKey(key)) {
       obj = undefined;
       break;
     }
@@ -24,6 +28,7 @@ function set (obj, path, value) {
   var keys = Array.isArray(path) ? path : path.split('.');
   for (var i = 0; i < keys.length - 1; i++) {
     var key = keys[i];
+    if (!isSafeKey(key)) return;
     if (deep.p && !hasOwnProp.call(obj, key)) obj[key] = {};
     obj = obj[key];
   }

--- a/test.js
+++ b/test.js
@@ -98,3 +98,52 @@ test('deep deletes', function (t) {
   t.equal(deep(obj, 'bar.baz.beep'), undefined);
   t.end();
 });
+
+test('do not get `__proto__`, `prototype` or `constructor` properties', function (t) {
+  var obj = {
+    isAdmin: false,
+    __proto__: {
+      isAdmin: true
+    },
+    prototype: {
+      isAdmin: true
+    },
+    constructor: {
+      isAdmin: true,
+      prototype: {
+        isAdmin: true
+      }
+    }
+  };
+
+  t.equal(deep(obj, 'isAdmin'), false);
+  t.equal(deep(obj, '__proto__.isAdmin'), undefined);
+  t.equal(deep(obj, 'prototype.isAdmin'), undefined);
+  t.equal(deep(obj, 'constructor.isAdmin'), undefined);
+  t.equal(deep(obj, 'constructor.prototype.isAdmin'), undefined);
+  t.end();
+});
+
+test('do not set `__proto__`, `prototype` or `constructor` properties', function (t) {
+  var obj = {};
+
+  deep.p = true;
+
+  deep(obj, 'isAdmin', false);
+  deep(obj, '__proto__.isAdmin', true);
+  deep(obj, 'prototype.isAdmin', true);
+  deep(obj, 'constructor.isAdmin', true);
+  deep(obj, 'constructor.prototype.isAdmin', true);
+
+  t.equal(obj.isAdmin, false);
+  t.equal(obj.__proto__ && obj.__proto__.isAdmin, undefined);
+  t.equal(obj.prototype && obj.prototype.isAdmin, undefined);
+  t.equal(obj.constructor && obj.constructor.isAdmin, undefined);
+  t.equal(
+    obj.constructor &&
+    obj.constructor.prototype &&
+    obj.constructor.prototype.isAdmin,
+    undefined
+  );
+  t.end();
+});


### PR DESCRIPTION
https://huntr.dev/users/VitorLuizC has fixed the Prototype Pollution vulnerability 🔨. VitorLuizC has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/deep-get-set/pull/2
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/deep-get-set/1/README.md

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-deep-get-set

### ⚙️ Description *

On get and set function I've checked if key is `__proto__`, `prototype` or `constructor` and if does, it don't set or get the value. I've also added unit tests to check against this fix.

### 💻 Technical Description *

I created `isSafeKey` that receives `key` and returns a `boolean` value to indicate if it is safe to be getted or setted. `isSafeKey` was added to if conditions in both `get` and `set` iterations.

- I've keep code-style.
- I've used just ES5 functions, to support any older brower or Node.js version.

### 🐛 Proof of Concept (PoC) *

```js
const deep = require('deep-get-set');

const obj = {};

deep.p = true;
deep(obj, '__proto__.hasOwnProperty', () => true);

const anyOtherObj = {};

anyOtherObj.hasOwnProperty('not its property');
//=> true;
```

### 🔥 Proof of Fix (PoF) *

```js
const deep = require('deep-get-set');

const obj = {};

deep.p = true;
deep(obj, '__proto__.hasOwnProperty', () => true);

const anyOtherObj = {};

anyOtherObj.hasOwnProperty('not its property');
//=> false;
```

### 👍 User Acceptance Testing (UAT)
- I've executed unit tests.
- I've added unit tests to prove the fix.